### PR TITLE
Adjust the `level` for "can" to avoid failing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Shopify.zip
+.DS_Store

--- a/Shopify/Avoid.yml
+++ b/Shopify/Avoid.yml
@@ -11,5 +11,4 @@ swap:
   blacklist: denylist or blocklist
   front line: customer, client, merchant, partner, or public-facing
   grandfather: inherited or legacy
-  able to: can
   # see: Display, available or review

--- a/Shopify/Vocabulary.yml
+++ b/Shopify/Vocabulary.yml
@@ -18,3 +18,4 @@ swap:
   '(?:OAuth|Oauth)': OAuth
   storefront API: Storefront API
   '(?:shopify CLI|shopify cli)': Shopify CLI
+  able to: can


### PR DESCRIPTION
Pushback over erroring on `can` instead of `able to`. There are some instances where `able to` is valid. For example, when we're indicating an upcoming feature. 

@stevemar is this all that's required to make the change? Other than creating a new release. 